### PR TITLE
Fix bitrate setting

### DIFF
--- a/edoStereo.plugin.js
+++ b/edoStereo.plugin.js
@@ -167,9 +167,7 @@ module.exports = (() => {
                       if (obj.fec) {
                         obj.fec = false; // disable forward error correction (fec)
                       }
-                      if (obj.encodingVoiceBitRate < selectedBitrate) {
-                          obj.encodingVoiceBitRate = selectedBitrate; // added
-                      }
+                      obj.encodingVoiceBitRate = parseInt(selectedBitrate); // added
                       setTransportOptions.call(thisObj.conn, obj);
                       if (!this.justJoined) {
                         Toasts.show("You're using edoStereo now!", { type: "info", timeout: 5000 });


### PR DESCRIPTION
Hi. Soweit ich das gerade getestet habe, wird die bitrate nicht gesetzt ~~, weil der Datentyp nicht passt (fehlendes `parseInt`)~~ 
Das `obj.encodingVoiceBitRate < selectedBitrate` habe ich entfernt, weil die Optionen für weniger Bitrate sonst nicht funzen (z.B. 48kbps in einem Channel mit 96kbps)